### PR TITLE
Make storage schemas configurable

### DIFF
--- a/files/storage-aggregation.conf
+++ b/files/storage-aggregation.conf
@@ -1,0 +1,29 @@
+[min]
+pattern = \.lower$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.upper$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[sum]
+pattern = \.sum$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[count]
+pattern = \.count$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[count_legacy]
+pattern = ^stats_counts.*
+xFilesFactor = 0
+aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.3
+aggregationMethod = average

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,15 @@ class graphite::config {
   $port = $::graphite::port
   $root_dir = $::graphite::root_dir
 
+  if ($::graphite::storage_aggregation_source == undef and
+      $::graphite::storage_aggregation_content == undef) {
+    $storage_aggregation_source = 'puppet:///modules/graphite/storage-aggregation.conf'
+    $storage_aggregation_content = undef
+  } else {
+    $storage_aggregation_source = $::graphite::storage_aggregation_source
+    $storage_aggregation_content = $::graphite::storage_aggregation_content
+  }
+
   if ($::graphite::storage_schemas_source == undef and
       $::graphite::storage_schemas_content == undef) {
     $storage_schemas_source = 'puppet:///modules/graphite/storage-schemas.conf'
@@ -37,6 +46,12 @@ class graphite::config {
   file { "${root_dir}/conf/carbon.conf":
     ensure    => present,
     content   => template('graphite/carbon.conf'),
+  }
+
+  file { "${root_dir}/conf/storage-aggregation.conf":
+    ensure    => present,
+    content   => $storage_aggregation_content,
+    source    => $storage_aggregation_source,
   }
 
   file { "${root_dir}/conf/storage-schemas.conf":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,12 @@
 # [*root_dir*]
 #   Where to install Graphite.
 #
+# [*storage_aggregation_content*]
+#   Optional: the content of the storage-aggregation.conf file.
+#
+# [*storage_aggregation_source*]
+#   Optional: the source of the storage-aggregation.conf file.
+
 # [*storage_schemas_content*]
 #   Optional: the content of the storage-schemas.conf file.
 #
@@ -23,6 +29,8 @@ class graphite(
   $admin_password = $graphite::params::admin_password,
   $port = $graphite::params::port,
   $root_dir = $graphite::params::root_dir,
+  $storage_aggregation_content = undef,
+  $storage_aggregation_source = undef,
   $storage_schemas_content = undef,
   $storage_schemas_source = undef
 ) inherits graphite::params {

--- a/spec/classes/graphite/graphite_spec.rb
+++ b/spec/classes/graphite/graphite_spec.rb
@@ -39,4 +39,19 @@ describe 'graphite', :type => :class do
     }
   end
 
+  context 'with unconfigured storage aggregation' do
+    it {
+      should contain_file('/opt/graphite/conf/storage-aggregation.conf').
+        with_source(/storage-aggregation\.conf/)
+    }
+  end
+
+  context 'with configured storage aggregation' do
+    let(:params) { {'storage_aggregation_content' => "Elephants and giraffes!" } }
+    it {
+      should contain_file('/opt/graphite/conf/storage-aggregation.conf').
+        with_content("Elephants and giraffes!")
+    }
+  end
+
 end


### PR DESCRIPTION
Make storage schemas configurable via a "storage_schemas" parameter to the
module. "storage_schemas" is an array of hashes, each of which contains:
- name: the (arbitrary) name of the schema group
- pattern: the regular expression pattern for matching metrics
- retentions: the string describing the schema retention policy
