### PR TITLE
Re-add --debug option (reverts #11)

### DIFF
--- a/templates/upstart/carbon-cache.conf
+++ b/templates/upstart/carbon-cache.conf
@@ -12,4 +12,4 @@ pre-start exec rm -f '<%= @root_dir %>'/storage/carbon-cache.pid
 chdir '<%= @root_dir %>'
 env GRAPHITE_STORAGE_DIR='<%= @root_dir %>/storage'
 env GRAPHITE_CONF_DIR='<%= @root_dir %>/conf'
-exec python '<%= @root_dir %>/bin/carbon-cache.py' start
+exec python '<%= @root_dir %>/bin/carbon-cache.py' --debug start


### PR DESCRIPTION
The --debug option is somewhat badly named -- it _both_ adds debug
output, _and_ causes carbon-cache to run in the foreground. Removing the
option in #11 caused the upstart script to lose track of the process as
carbon-cache started unexpectedly daemonizing.

Ideally we want to have a way of running through upstart without the
debug output, but this will fix the immediate problem.

cc @KushalP @dcarley @tombooth @nosborn
