### PR TITLE
Add syntax checks to `rake test`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "http://rubygems.org"
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
 
 gem "rake"
+gem "puppet-syntax"
 gem "puppet-lint"
 gem "rspec-puppet"
 gem "puppetlabs_spec_helper"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
 
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
@@ -19,6 +20,7 @@ PuppetLint.configuration.ignore_paths = exclude_paths
 
 desc "Run syntax, lint, and spec tests."
 task :test => [
+  :syntax,
   :lint,
   :spec,
 ]


### PR DESCRIPTION
Despite the task description, these were omitted when the repo was copied or
brought inline with gds-operations/puppet-module-skeleton.

/cc @philandstuff 
