### PR TITLE
Graphite web interface bind_address now configurable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
 gem "rake"
 gem "puppet-syntax"
 gem "puppet-lint"
+gem "rspec", '< 3.0.0'
 gem "rspec-puppet"
 gem "puppetlabs_spec_helper"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@
 class graphite::config {
 
   $admin_password = $::graphite::admin_password
+  $bind_address = $::graphite::bind_address
   $port = $::graphite::port
   $root_dir = $::graphite::root_dir
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,11 +8,17 @@
 # [*admin_password*]
 #   The (hashed) initial admin password.
 #
+# [*bind_address*]
+#   The address on which to serve the graphite-web user interface.
+#   Default: 127.0.0.1
+#
 # [*port*]
 #   The port on which to serve the graphite-web user interface.
+#   Default: 8000
 #
 # [*root_dir*]
 #   Where to install Graphite.
+#   Default: /opt/graphite
 #
 # [*carbon_aggregator*]
 #   Optional: Boolean, whether to run carbon-aggregator. You will need to
@@ -44,6 +50,7 @@
 #
 class graphite(
   $admin_password = $graphite::params::admin_password,
+  $bind_address = $graphite::params::bind_address,
   $port = $graphite::params::port,
   $root_dir = $graphite::params::root_dir,
   $carbon_aggregator = false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@
 #
 class graphite::params {
   $admin_password = 'sha1$1b11b$edeb0a67a9622f1f2cfeabf9188a711f5ac7d236'
+  $bind_address = '127.0.0.1'
   $port = 8000
   $root_dir = '/opt/graphite'
   $version = '0.9.12'

--- a/spec/classes/graphite/graphite__config_spec.rb
+++ b/spec/classes/graphite/graphite__config_spec.rb
@@ -44,6 +44,7 @@ describe 'graphite', :type => :class do
            with_content(/PYTHONPATH='\/this\/is\/root\/webapp'/).
            with_content(/GRAPHITE_STORAGE_DIR='\/this\/is\/root\/storage'/).
            with_content(/GRAPHITE_CONF_DIR='\/this\/is\/root\/conf'/).
+           with_content(/-b127\.0\.0\.1:8000/).
            with_mode('0555') }
     end
 

--- a/templates/upstart/graphite-web.conf
+++ b/templates/upstart/graphite-web.conf
@@ -11,4 +11,4 @@ chdir '<%= @root_dir %>/webapp'
 env PYTHONPATH='<%= @root_dir %>/webapp'
 env GRAPHITE_STORAGE_DIR='<%= @root_dir %>/storage'
 env GRAPHITE_CONF_DIR='<%= @root_dir %>/conf'
-exec <%= @root_dir %>/bin/gunicorn_django -b127.0.0.1:<%= @port %> -w2 graphite/settings.py
+exec <%= @root_dir %>/bin/gunicorn_django -b<%= @bind_address -%>:<%= @port %> -w2 graphite/settings.py


### PR DESCRIPTION
This pulls in some changes proposed in #23, changes things slightly to
use the `params.pp` class, adds tests and puppetdoc.

I've also locked the rspec version at <3.0.0 because the 3.0.0 version
has broken rspec-puppet and that's what I get installed when I try to
bundle this repo. See rodjek/rspec-puppet#198

Closes #23.

/cc @philandstuff 
