### PR TITLE
restart apps when upgrading packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,7 +126,7 @@ class graphite(
     Class['graphite::deps'] -> Class['graphite::install']
   }
 
-  class{'graphite::install': } ->
+  class{'graphite::install': } ~>
   class{'graphite::config': } ~>
   class{'graphite::service': } ->
   Class['graphite']


### PR DESCRIPTION
Currently, if you change the requested version to cause an upgrade (or
downgrade), the existing service will just keep running.  If this module
wants to manage the installation of the graphite packages, doesn't it
make sense that it should restart the services as well if the package
version changes?

I tried digging in the commit history to see if there was a rationale
for the current behaviour: d83763115 introduced this behaviour, saying
only that it is the "prefered pattern".
