### PR TITLE
Change permissions of root_dir

### DIFF
--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -11,7 +11,9 @@
 class graphite::deps {
   $root_dir = $::graphite::root_dir
 
-  python::virtualenv { $root_dir: } ->
+  python::virtualenv { $root_dir:
+    mode => '0755',
+  } ->
   python::pip { [
     'gunicorn',
     'twisted==11.1.0',


### PR DESCRIPTION
The acceptance tests have been broken since the default user that the
daemons run as was changed to `www-data` in 473da93. This was noted in #31
but got lost when it transferred to #32.

This is because `python::virtualenv` creates the `root_dir` with permissions
of `0750` which prevents the upstart jobs from accessing the `/bin`
directory, amongst other things.

Fix this by relaxing the permissions on that directory so that anyone can
list it's contents. It doesn't contain anything read-sensitive, so this
should be fine. The other option would be to change the ownership to match
the user that the daemons are running as, but I don't think that's necessary
or correct.