### PR TITLE
[#85067926] Fix and test for pip install bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
 
 gem 'beaker', '>= 1.17.2', :require => false
 gem 'beaker-rspec',        :require => false
+gem 'vagrant-wrapper'
 gem "rake"
 gem "puppet-syntax"
 gem "puppet-lint"

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,24 +1,12 @@
 require 'spec_helper_acceptance'
 
-describe 'graphite' do
+shared_examples_for "working graphite" do |puppet_manifest|
   it 'should run successfully' do
-    pp = <<-END
-      class { 'python':
-        pip        => true,
-        dev        => true,
-        virtualenv => true,
-      }
-
-      class { 'graphite':
-        require => Class['python'],
-      }
-    END
-
     # Apply twice to ensure no errors the second time.
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(puppet_manifest, :catch_failures => true) do |r|
       expect(r.stderr).not_to match(/error/i)
     end
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(puppet_manifest, :catch_failures => true) do |r|
       expect(r.stderr).not_to match(/error/i)
 
       # ensure idempotency
@@ -42,5 +30,36 @@ describe 'graphite' do
     it 'should serve dashboard without errors' do
       shell('curl -fsS http://localhost:8000/dashboard/')
     end
+  end
+end
+
+describe 'graphite' do
+  context 'default params' do
+    it_should_behave_like "working graphite", <<-END
+      class { 'python':
+        pip        => true,
+        dev        => true,
+        virtualenv => true,
+      }
+
+      class { 'graphite':
+        require => Class['python'],
+      }
+    END
+  end
+
+  context 'custom root_dir' do
+    it_should_behave_like "working graphite", <<-END
+      class { 'python':
+        pip        => true,
+        dev        => true,
+        virtualenv => true,
+      }
+
+      class { 'graphite':
+        root_dir => '/usr/local/graphite',
+        require  => Class['python'],
+      }
+    END
   end
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -31,6 +31,12 @@ shared_examples_for "working graphite" do |puppet_manifest|
       shell('curl -fsS http://localhost:8000/dashboard/')
     end
   end
+
+  describe 'carbon and graphite-web' do
+    it 'should work end-to-end' do
+      run_script_on(hosts.first, File.expand_path('../graphite_integration.rb', __FILE__))
+    end
+  end
 end
 
 describe 'graphite' do

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -39,10 +39,8 @@ describe 'graphite' do
 
   describe service('graphite-web') do
     it { should be_running }
-    it 'should open port 8000' do
-      # graphite-web listens on 127.0.0.1 so the port_open? method
-      # won't see it
-      shell('nc -z 127.0.0.1 8000')
+    it 'should serve dashboard without errors' do
+      shell('curl -fsS http://localhost:8000/dashboard/')
     end
   end
 end

--- a/spec/acceptance/graphite_integration.rb
+++ b/spec/acceptance/graphite_integration.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+require 'socket'
+require 'net/http'
+require 'json'
+
+CARBON_PORT = 2003
+GRAPHITE_PORT = 8000
+
+def send_metric(name, value, carbon_port=2003)
+  sock = TCPSocket.new('localhost', carbon_port)
+  sock.puts "#{name} #{value} #{Integer(Time.now)}"
+  sock.close
+end
+
+def get_metric(name, value, graphite_port=8000)
+  uri = URI("http://localhost:#{graphite_port}/render?from=-1minss&until=now&target=#{name}&format=json")
+  resp = Net::HTTP.get(uri)
+
+  data = JSON::load(resp)
+  return false unless \
+    data.size == 1 && \
+    data.first['target'] == name && \
+    data.first.has_key?('datapoints')
+
+  match = data.first['datapoints'].select { |dp| dp.first == value }
+  return false unless match.size == 1
+
+  return true
+end
+
+def get_metric_retry(*args)
+  10.times do |attempt|
+    return true if get_metric(*args)
+    puts "Attempt #{attempt+1} failed"
+    sleep 0.5
+  end
+
+  return false
+end
+
+name, value = "foo.bar", rand()
+send_metric(name, value, CARBON_PORT)
+success = get_metric_retry(name, value, GRAPHITE_PORT)
+
+raise "Unable to get metric our from Graphite" unless success
+puts "All OK"

--- a/spec/classes/graphite/graphite__config_spec.rb
+++ b/spec/classes/graphite/graphite__config_spec.rb
@@ -49,7 +49,7 @@ describe 'graphite', :type => :class do
            with_content(/setuid www-data/).
            with_content(/setgid www-data/).
            with_content(/chdir '\/this\/is\/root\/webapp'/).
-           with_content(/PYTHONPATH='\/this\/is\/root\/webapp'/).
+           with_content(/PYTHONPATH='\/this\/is\/root\/lib:\/this\/is\/root\/webapp'/).
            with_content(/GRAPHITE_STORAGE_DIR='\/this\/is\/root\/storage'/).
            with_content(/GRAPHITE_CONF_DIR='\/this\/is\/root\/conf'/).
            with_content(/-b127\.0\.0\.1:8000/).

--- a/templates/upstart/graphite-web.conf
+++ b/templates/upstart/graphite-web.conf
@@ -10,7 +10,7 @@ setgid <%= @group %>
 respawn
 
 chdir '<%= @root_dir %>/webapp'
-env PYTHONPATH='<%= @root_dir %>/webapp'
+env PYTHONPATH='<%= @root_dir %>/lib:<%= @root_dir %>/webapp'
 env GRAPHITE_STORAGE_DIR='<%= @root_dir %>/storage'
 env GRAPHITE_CONF_DIR='<%= @root_dir %>/conf'
 exec <%= @gunicorn_bin %> -b<%= @bind_address -%>:<%= @port %> -w2 graphite/settings.py


### PR DESCRIPTION
#### Improve acceptance test for graphite-web service

Test that Graphite can successfully serve a request for the dashboard rather
than just testing that it has bound to the port.

This exposes a problem introduced by the `python::pip` changes first in
ed5642d when used with the default `root_dir` of `/opt/graphite`. It
prevents `graphite-web` from being able to load `whisper` and causes it to
respond with a backtrace ending in:

    ImportError: No module named whisper

This was first noticed when bringing up our `graphite-1.management` machine
and recorded in Pivotal [#85067926]. I'm not sure what the fix for this is
yet, so that will follow in a subsequent commit.

PS: I could have use the `curl_on` helper instead of `shell` but it's not
clear to me whether I need to wrap it in an `expect{}` or what value it
provides.

#### Extend acceptance tests to cover custom root_dir

This will prevent us from breaking the functionality in ed5642d again.

#### Fix graphite-web service with default root_dir

Add `lib/` to `PYTHONPATH` so that graphite-web is able to load the
`whisper` module when it's installed to the default `root_dir` of
`/opt/graphite`.

This was fixed for custom `root_dir` values in ed5642d but broke the default
use case. I don't really understand the specifics of why, but this seems
like a reasonable fix.

#### Add script to end-to-end test Carbon and Graphite

This sends a metric to Carbon and then reads it back out of Graphite to
ensure that everything is working correctly. It should give us greater
confidence when reviewing pull requests to this repo in future.

#### Add vagrant-wrapper to Gemfile

This appears to be an implicit dependency of later Beaker versions.
Otherwise I get this error:

    ➜  puppet-graphite git:(85067926-pip_install_bug) b rake acceptance:ubuntu1204
    Running acceptance tests for Ubuntu
    /opt/rubies/1.9.3-p545/bin/ruby -S rspec spec/acceptance
    Beaker::Hypervisor, found some vagrant boxes to create
    /Users/dcarley/vendor/bundle/gems/beaker-2.3.0/lib/beaker/hypervisor/vagrant.rb:172:in `block (2 levels) in vagrant_cmd': Failed to exec 'vagrant destroy --force'. Error was /opt/rubies/1.9.3-p545/lib/ruby/gems/1.9.1/gems/bundler-1.5.3/lib/bundler/rubygems_integration.rb:240:in `block in replace_gem': vagrant-wrapper is not part of the bundle. Add it to Gemfile. (Gem::LoadError) (RuntimeError)