### PR TITLE
[Fixes #85067926] Revert permission fix and release 2.0.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.0.3 2015-03-27
+- Fix `graphite-web` install when using pip and default `root_dir`
+- Restart services when changing package versions
+- Improve acceptance and integration test coverage
+- Remove support for Ruby 1.8.7 and 1.9.2
+
 2.0.2 2014-12-15
 - Lock beaker dependency to ~> 1.17.0 to allow testing on ruby<1.9.3
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'gdsoperations-graphite'
-version       '2.0.2'
+version       '2.0.3'
 author        'Government Digital Service'
 license       'MIT'
 summary       'Module to manage the Graphite monitoring tool'

--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -11,9 +11,7 @@
 class graphite::deps {
   $root_dir = $::graphite::root_dir
 
-  python::virtualenv { $root_dir:
-    mode => '0755',
-  } ->
+  python::virtualenv { $root_dir: } ->
   python::pip { [
     'gunicorn',
     'twisted==11.1.0',


### PR DESCRIPTION
This reverts commit 979454a.

Which is good, because by overriding the `mode` param we would have been
forcing people to use `>= 1.8.3`.

This has been fixed upstream by changing the default mode in
stankevich/puppet-python@83ae489. The problem now only affects puppet-python
1.8.3 which has the orginal commit stankevich/puppet-python@f3e3695.

/cc @alext 