### PR TITLE
Update pid file name for carbon-cache

### DIFF
--- a/templates/upstart/carbon-cache.conf
+++ b/templates/upstart/carbon-cache.conf
@@ -10,7 +10,7 @@ setgid <%= @group %>
 
 respawn
 
-pre-start exec rm -f '<%= @root_dir %>'/storage/carbon-cache.pid
+pre-start exec rm -f '<%= @root_dir %>'/storage/carbon-cache-a.pid
 
 chdir '<%= @root_dir %>'
 env GRAPHITE_STORAGE_DIR='<%= @root_dir %>/storage'


### PR DESCRIPTION
It would seem that carbon-cache now uses a different name for its pid
file.
Update this in the upstart job.
Fixes #41