### PR TITLE
Move single quote in carbon-cache pre-start

### DIFF
--- a/templates/upstart/carbon-cache.conf
+++ b/templates/upstart/carbon-cache.conf
@@ -10,7 +10,7 @@ setgid <%= @group %>
 
 respawn
 
-pre-start exec rm -f '<%= @root_dir %>'/storage/carbon-cache-a.pid
+pre-start exec rm -f '<%= @root_dir %>/storage/carbon-cache-a.pid'
 
 chdir '<%= @root_dir %>'
 env GRAPHITE_STORAGE_DIR='<%= @root_dir %>/storage'


### PR DESCRIPTION
This quote was added in 8a8dc2f1e6aee431ab328a196d408a57fabb9f9c.

I assume it was added to prevent spaces in `root_dir` from removing multiple files, but it looks weird to have a quote in the middle of a path:

```
'/opt/graphite'/storage/carbon-cache-a.pid
```

I think moving the quote to the end of the line will have the same effect but looks a little bit more normal.