### PR TITLE
Run TravisCI builds in containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+# Run inside a container
+sudo: false
 # Verify this with: http://lint.travis-ci.org/
 language: ruby
 # Delete dependency locks for matrix builds.


### PR DESCRIPTION
TravisCI now supports containerised builds, per
blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/.

Enable them.