### PR TITLE
Update the vagrant to use trusty.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,8 +26,7 @@ puppet apply --verbose -e "node default { \
 EOM
 
 Vagrant.configure("2") do |config|
-  config.vm.box = 'precise64'
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = 'ubuntu/trusty64'
   config.vm.hostname = "graphite.internal"
 
   config.vm.synced_folder ".", "/etc/puppet/modules/graphite"


### PR DESCRIPTION
We're moving away from precise in our infrastructure.