### PR TITLE
Update the travis testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,19 @@ before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
 env:
   matrix:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.8.5"
+  - PUPPET_VERSION="~> 4.3.2"
+# https://tickets.puppetlabs.com/browse/PUP-3796
+matrix:
+  exclude:
+    - rvm: 2.2.0
+      env: PUPPET_VERSION="~> 3.8.5"
+
 # Only notify for failed builds.
 notifications:
   email:


### PR DESCRIPTION
We should test on the versions of the software we use, and want to use,
rather than older unsupported oned.