### PR TITLE
Pin gunicorn to latest compatible version

### DIFF
--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -13,7 +13,7 @@ class graphite::deps {
 
   python::virtualenv { $root_dir: } ->
   python::pip { [
-    'gunicorn',
+    'gunicorn==19.6.0',
     'twisted==11.1.0',
     'django==1.4.10',
     'django-tagging==0.3.1',


### PR DESCRIPTION
Since gunicorn 19.7.0, the `gunicorn_django` script no longer exists (it was previously deprecated).

This PR just pins gunicorn to the latest compatible version so that the module actually works for them. At least until a better solution is implemented.

Fixes #57 