### PR TITLE
Pin the version of gunicorn to 19.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.0.6 2017-07-27
+- Pin `gunicorn` to 19.3.0 so that this continues to work with `pip`
+
 2.0.5 2015-10-06
 - Include pytz dependency
 

--- a/manifests/deps.pp
+++ b/manifests/deps.pp
@@ -13,7 +13,7 @@ class graphite::deps {
 
   python::virtualenv { $root_dir: } ->
   python::pip { [
-    'gunicorn',
+    'gunicorn==19.3.0',
     'twisted==11.1.0',
     'django==1.4.10',
     'django-tagging==0.3.1',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":         "gdsoperations-graphite",
-  "version":      "2.0.5",
+  "version":      "2.0.6",
   "author":       "Government Digital Service",
   "license":      "MIT",
   "summary":      "Module to manage the Graphite monitoring tool",

--- a/spec/classes/graphite/graphite__deps_spec.rb
+++ b/spec/classes/graphite/graphite__deps_spec.rb
@@ -9,7 +9,7 @@ describe 'graphite', :type => :class do
     }}
 
     it { should contain_python__virtualenv('/this/is/root') }
-    it { should contain_python__pip('gunicorn').with_virtualenv('/this/is/root') }
+    it { should contain_python__pip('gunicorn==19.3.0').with_virtualenv('/this/is/root') }
 
     it { should contain_package('python-cairo').with_ensure('present') }
     it { should contain_file('/this/is/root/lib/python2.7/site-packages/cairo').


### PR DESCRIPTION
- This wasn't pinned previously, and so installing this from scratch
  installed the latest version from `pip`: `19.7.1`. This made
  `gunicorn_django` not work because it had been merged into `gunicorn`
  itself. In the spirit of "lift and shift to AWS", rather than update
  this, continue with the behaviour that is currently on Carrenza.