### PR TITLE
Make the worker processes for graphite-web configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleased
 - Switch to using Vox Pupuli for the Python module
+- Make the worker processes for graphite-web configurable.
 
 2.0.6 2017-07-27
 - Pin `gunicorn` to 19.3.0 so that this continues to work with `pip`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class graphite::config {
   $admin_password = $::graphite::admin_password
   $bind_address = $::graphite::bind_address
   $port = $::graphite::port
+  $worker_processes = $::graphite::worker_processes
   $root_dir = $::graphite::root_dir
   $user = $::graphite::user
   $group = $::graphite::group

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,10 @@
 #   The port on which to serve the graphite-web user interface.
 #   Default: 8000
 #
+# [*worker_processes*]
+#   The number of worker processes for handling requests.
+#   Default: 2
+#
 # [*root_dir*]
 #   Where to install Graphite.
 #   Default: /opt/graphite
@@ -95,6 +99,7 @@ class graphite(
   $admin_password = $graphite::params::admin_password,
   $bind_address = $graphite::params::bind_address,
   $port = $graphite::params::port,
+  $worker_processes = $graphite::params::worker_processes,
   $root_dir = $graphite::params::root_dir,
   $carbon_aggregator = false,
   $carbon_max_cache_size = 'inf',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class graphite::params {
   $port = 8000
   $root_dir = '/opt/graphite'
   $version = '0.9.12'
+  $worker_processes = 2
   $user = 'www-data'
   $group = 'www-data'
   $time_zone = 'UTC'

--- a/templates/upstart/graphite-web.conf
+++ b/templates/upstart/graphite-web.conf
@@ -13,4 +13,4 @@ chdir '<%= @root_dir %>/webapp'
 env PYTHONPATH='<%= @root_dir %>/lib:<%= @root_dir %>/webapp'
 env GRAPHITE_STORAGE_DIR='<%= @root_dir %>/storage'
 env GRAPHITE_CONF_DIR='<%= @root_dir %>/conf'
-exec <%= @gunicorn_bin %> -b<%= @bind_address -%>:<%= @port %> -w2 graphite/settings.py
+exec <%= @gunicorn_bin %> -b<%= @bind_address -%>:<%= @port %> -w<%= @worker_processes -%> graphite/settings.py


### PR DESCRIPTION
This should be useful when hosting graphite on a machine with more
than two cores, as you should be able to utilise more of the available
cores if desired.